### PR TITLE
Allow line types to be disabled/enabled in the config

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -70,8 +70,8 @@ This shows optional fields with some suggested values.
 ```yaml
 # Customise which kinds of log messages should be sent to Discord
 log_messages:
-  connection_attempt: False
-  connection_booted: False
+  connection_attempt: False # Warning: This will reveal users' IP addresses
+  connection_booted: False # Warning: This will reveal users' IP addresses
   player_joined: True
   player_left: True
   chat_message: True

--- a/readme.md
+++ b/readme.md
@@ -68,6 +68,17 @@ discord_webhook_url: https://discord.com/api/webhooks/1234567890/abcdefghijklmno
 This shows optional fields with some suggested values.
 
 ```yaml
+# Customise which kinds of log messages should be sent to Discord
+log_messages:
+  connection_attempt: False
+  connection_booted: False
+  player_joined: True
+  player_left: True
+  chat_message: True
+  world_backup: False
+  terraria_error: False
+  server_listening: True
+  server_stopped: True
 # When provided, Slime Hook will be restarted if certain errors occur, such as the container being stopped or removed
 # This is useful when the script is automatically running in the background
 # The auto-retry feature will only be enabled for error types specified under `auto_retry`

--- a/slime_hook.py
+++ b/slime_hook.py
@@ -28,8 +28,8 @@ class EnabledLogMessages(BaseModel):
     player_joined: bool = True
     player_left: bool = True
     chat_message: bool = True
-    world_backup: bool = True
-    terraria_error: bool = True
+    world_backup: bool = False
+    terraria_error: bool = False
     server_listening: bool = True
     server_stopped: bool = True
 

--- a/slime_hook.py
+++ b/slime_hook.py
@@ -181,7 +181,6 @@ class SlimeHook:
     def handle_line(self, line: str):
         line = line.strip()
         for line_type in self.LINE_TYPES:
-            # TODO: Check config
             did_process_line = line_type.process_line(line)
             if did_process_line:
                 return line_type

--- a/slime_hook.py
+++ b/slime_hook.py
@@ -94,7 +94,7 @@ class SlimeHook:
                 r"^([\d\.]{7,15}):\d{1,5} is connecting\.\.\.",
                 is_enabled=self.config.log_messages.connection_attempt,
                 callback=lambda ip: self.send_discord_message(
-                    f"Connection attempt from **{ip}**"
+                    f"Connection attempt from {ip}"
                 ),
                 capture_groups=1,
             ),
@@ -103,7 +103,7 @@ class SlimeHook:
                 r"^([\d\.]{7,15}):\d{1,5} was booted: Invalid operation at this state\.",
                 is_enabled=self.config.log_messages.connection_booted,
                 callback=lambda ip: self.send_discord_message(
-                    f"Connection from **{ip}** was booted"
+                    f"Connection from {ip} was booted"
                 ),
                 capture_groups=1,
             ),

--- a/slime_hook.py
+++ b/slime_hook.py
@@ -22,11 +22,24 @@ class DockerConnection(BaseModel):
     base_url: str
 
 
+class EnabledLogMessages(BaseModel):
+    connection_attempt: bool = False
+    connection_booted: bool = False
+    player_joined: bool = True
+    player_left: bool = True
+    chat_message: bool = True
+    world_backup: bool = True
+    terraria_error: bool = True
+    server_listening: bool = True
+    server_stopped: bool = True
+
+
 class Config(BaseModel):
     container: str
     discord_webhook_url: str
     auto_retry: Optional[AutoRetryConfigs] = None
     docker_connection: Optional[DockerConnection] = None
+    log_messages: EnabledLogMessages = EnabledLogMessages()
 
 
 class LogLineType:
@@ -34,6 +47,7 @@ class LogLineType:
         self,
         name: str,
         regex: str,
+        is_enabled: bool = False,
         callback: Optional[Callable[..., None]] = None,
         capture_groups: int = 0,
     ):
@@ -41,6 +55,7 @@ class LogLineType:
         self.regex = regex
         self.callback = callback
         self.capture_groups = capture_groups
+        self.is_enabled = is_enabled
 
     def match(self, line: str):
         return re.compile(self.regex).match(line)
@@ -55,7 +70,7 @@ class LogLineType:
                 f"Expected {self.capture_groups} capture groups, but got {len(groups)}"
             )
 
-        if self.callback:
+        if self.is_enabled and self.callback:
             self.callback(*groups)
         return True
 
@@ -70,15 +85,19 @@ class SlimeHook:
         # FIXME: Regex doesn't handle IPv6 addresses (not that I've spotted any in the wild yet :/)
         self.LINE_TYPES = [
             LogLineType(
-                "connection_attempt", r"^[\d\.]{7,15}:\d{1,5} is connecting\.\.\."
+                "connection_attempt",
+                r"^[\d\.]{7,15}:\d{1,5} is connecting\.\.\.",
+                is_enabled=self.config.log_messages.connection_attempt,
             ),
             LogLineType(
                 "connection_booted",
                 r"^[\d\.]{7,15}:\d{1,5} was booted: Invalid operation at this state\.",
+                is_enabled=self.config.log_messages.connection_booted,
             ),
             LogLineType(
                 "player_joined",
                 r"^(.*) has joined.$",
+                is_enabled=self.config.log_messages.player_joined,
                 callback=lambda player: self.send_discord_message(
                     f":inbox_tray: **{player}** has joined"
                 ),
@@ -87,6 +106,7 @@ class SlimeHook:
             LogLineType(
                 "player_left",
                 r"^(.*) has left.$",
+                is_enabled=self.config.log_messages.player_left,
                 callback=lambda player: self.send_discord_message(
                     f":outbox_tray: **{player}** has left"
                 ),
@@ -95,13 +115,17 @@ class SlimeHook:
             LogLineType(
                 "chat_message",
                 r"^<(.*)> (.*)$",
+                is_enabled=self.config.log_messages.chat_message,
                 callback=lambda player, message: self.send_discord_message(
                     f"<**{player}**> {message}"
                 ),
                 capture_groups=2,
             ),
             LogLineType(
-                "world_save_progress", r"^Saving world data: (\d+)%", capture_groups=1
+                "world_save_progress",
+                r"^Saving world data: (\d+)%",
+                is_enabled=self.config.log_messages.world_backup,
+                capture_groups=1,
             ),
             LogLineType(
                 "world_validation_progress",
@@ -111,11 +135,16 @@ class SlimeHook:
             LogLineType(
                 "world_backup",
                 r"^Backing up world file",
+                is_enabled=self.config.log_messages.world_backup,
                 callback=lambda: self.send_discord_message(
                     "_Backup successfully created_"
                 ),
             ),
-            LogLineType("terraria_error", r"^Error on message Terraria\.MessageBuffer"),
+            LogLineType(
+                "terraria_error",
+                r"^Error on message Terraria\.MessageBuffer",
+                is_enabled=self.config.log_messages.terraria_error,
+            ),
             LogLineType(
                 "world_load_objects_progress",
                 r"^Resetting game objects (\d+)%",
@@ -134,6 +163,7 @@ class SlimeHook:
             LogLineType(
                 "server_listening",
                 r"^Listening on port \d+",
+                is_enabled=self.config.log_messages.server_listening,
                 callback=lambda: self.send_discord_message(
                     ":zap: **Server has started!**"
                 ),
@@ -151,6 +181,7 @@ class SlimeHook:
     def handle_line(self, line: str):
         line = line.strip()
         for line_type in self.LINE_TYPES:
+            # TODO: Check config
             did_process_line = line_type.process_line(line)
             if did_process_line:
                 return line_type

--- a/slime_hook.py
+++ b/slime_hook.py
@@ -75,7 +75,7 @@ class LogLineType:
                 self.callback(*groups)
             else:
                 print(
-                    f"Warning: Sending {self.name} log messages is enabled, but there is no callback"
+                    f"Warning: Tried to send a {self.name} log message, but it has not been implemented"
                 )
         return True
 

--- a/slime_hook.py
+++ b/slime_hook.py
@@ -91,13 +91,21 @@ class SlimeHook:
         self.LINE_TYPES = [
             LogLineType(
                 "connection_attempt",
-                r"^[\d\.]{7,15}:\d{1,5} is connecting\.\.\.",
+                r"^([\d\.]{7,15}):\d{1,5} is connecting\.\.\.",
                 is_enabled=self.config.log_messages.connection_attempt,
+                callback=lambda ip: self.send_discord_message(
+                    f"Connection attempt from **{ip}**"
+                ),
+                capture_groups=1,
             ),
             LogLineType(
                 "connection_booted",
-                r"^[\d\.]{7,15}:\d{1,5} was booted: Invalid operation at this state\.",
+                r"^([\d\.]{7,15}):\d{1,5} was booted: Invalid operation at this state\.",
                 is_enabled=self.config.log_messages.connection_booted,
+                callback=lambda ip: self.send_discord_message(
+                    f"Connection from **{ip}** was booted"
+                ),
+                capture_groups=1,
             ),
             LogLineType(
                 "player_joined",
@@ -149,6 +157,9 @@ class SlimeHook:
                 "terraria_error",
                 r"^Error on message Terraria\.MessageBuffer",
                 is_enabled=self.config.log_messages.terraria_error,
+                callback=lambda: self.send_discord_message(
+                    "_Terraria.MessageBuffer error from the server_"
+                ),
             ),
             LogLineType(
                 "world_load_objects_progress",

--- a/slime_hook.py
+++ b/slime_hook.py
@@ -237,7 +237,8 @@ class SlimeHook:
                 line_buffer = lines[-1]
 
         # If we get here then it usually means the container has stopped
-        self.send_discord_message(":skull: **Server has stopped**")
+        if self.config.log_messages.server_stopped:
+            self.send_discord_message(":skull: **Server has stopped**")
         raise ContainerNotRunning(f'Container "{container.name}" is not running')
 
     def run_with_auto_retry(self):

--- a/slime_hook.py
+++ b/slime_hook.py
@@ -51,7 +51,7 @@ class LogLineType:
         callback: Optional[Callable[..., None]] = None,
         capture_groups: int = 0,
     ):
-        name = name
+        self.name = name
         self.regex = regex
         self.callback = callback
         self.capture_groups = capture_groups
@@ -70,8 +70,13 @@ class LogLineType:
                 f"Expected {self.capture_groups} capture groups, but got {len(groups)}"
             )
 
-        if self.is_enabled and self.callback:
-            self.callback(*groups)
+        if self.is_enabled:
+            if self.callback:
+                self.callback(*groups)
+            else:
+                print(
+                    f"Warning: Sending {self.name} log messages is enabled, but there is no callback"
+                )
         return True
 
 


### PR DESCRIPTION
ALL THE LOG MESSAGES
```yaml
log_messages:
  connection_attempt: True
  connection_booted: True
  player_joined: True
  player_left: True
  chat_message: True
  world_backup: True
  terraria_error: True
  server_listening: True
  server_stopped: True
```

wow
![image](https://github.com/user-attachments/assets/2c100da9-2ad5-4e02-b903-933f53dbea78)
